### PR TITLE
Improve frontend

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -42,6 +42,11 @@ header {
 	top: 50px;
 }
 
+.buttontext {
+	width: 45px;
+	text-align: center;
+}
+
 #frame {
 	position: relative;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -75,18 +75,18 @@ header {
 }
 #frame .page .meeting label {
 	font-weight: normal !important;
+	text-align: center;
 }
 #frame .page .meeting input.name {
 	text-align: right;
 	width: 70px;
 	margin-bottom: -20px;
-	margin-left: -20px;
+	margin-left: -50px;
 }
 #frame .page .meeting input.date {
 	text-align: center;
 	width: 150px;
 	padding: 0;
-	margin-right: -65px;
 	margin-top: -20px;
 }
 

--- a/static/style.css
+++ b/static/style.css
@@ -7,10 +7,11 @@
 	border: none;
 	width: 100%;
 	min-height: 150px;
+	resize: vertical;
 }
 #frame .page textarea.att {
 	padding: 0;
-	text-indent: 30px;
+	margin-left: 40px;
 	min-height: 0px;
 	margin-top: -22px;
 	background: transparent;

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,13 +28,26 @@
         <div class="header-inner">
           <div class="row">
             <div class="header-left col-md-2">
-              <a href="#" @click="submittex" class="primary-action">TeX</a>
+              <a href="#" @click="clearContent" class="primary-action">Clear</a>
             </div>
             <div class="col-md-8">
-              <h2>Motioner</h2>
             </div>
             <div class="header-right col-md-2">
-              <a href="#" @click="submitpdf" class="primary-action">PDF</a>
+              <a href="#" @click="submitpdf" class="primary-action">
+                <div style="width:35px; text-align: center;">
+                  PDF
+                </div>
+              </a>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col-md-10"> <h2>Motioner</h2> </div>
+            <div class="header-right col-md-2">
+              <a href="#" @click="submittex" class="primary-action">
+                <div style="width:35px; text-align: center;">
+                  TeX
+                </div>
+              </a>
             </div>
           </div>
           <div class="clear"></div>
@@ -189,6 +202,7 @@
             localStorage.removeItem('background')
             localStorage.removeItem('items')
             localStorage.removeItem('authors')
+            window.location.reload();
           }
         }
       })

--- a/templates/index.html
+++ b/templates/index.html
@@ -60,7 +60,7 @@
 
       <div id="frame">
         <div class="page">
-          <form ref="form" action="/motion.pdf" method="POST">
+          <form ref="form" action="/motion.pdf" method="POST" target="_blank">
             <h1>
               <select name="document_type" id="document_type" v-model="document_type">
                 <option value="motion">Motion angående</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,13 +28,17 @@
         <div class="header-inner">
           <div class="row">
             <div class="header-left col-md-2">
-              <a href="#" @click="clearContent" class="primary-action">Clear</a>
+              <a href="#" @click="clearContent" class="primary-action">
+                <div class="buttontext">
+                  Clear
+                </div>
+              </a>
             </div>
             <div class="col-md-8">
             </div>
             <div class="header-right col-md-2">
               <a href="#" @click="submitpdf" class="primary-action">
-                <div style="width:35px; text-align: center;">
+                <div class="buttontext">
                   PDF
                 </div>
               </a>
@@ -44,7 +48,7 @@
             <div class="col-md-10"> <h2>Motioner</h2> </div>
             <div class="header-right col-md-2">
               <a href="#" @click="submittex" class="primary-action">
-                <div style="width:35px; text-align: center;">
+                <div class="buttontext">
                   TeX
                 </div>
               </a>
@@ -76,7 +80,8 @@
               <input @keyup="keyUpMeeting()"
                      v-model="meeting"
                      type="text"
-                     name="meeting" class="name"
+                     name="meeting"
+                     class="name"
                      placeholder="Glögg"><label for="meeting">-SM</label>
               <br>
               <input @keyup="keyUpDate()"

--- a/templates/index.html
+++ b/templates/index.html
@@ -74,8 +74,13 @@
 
               <ul id="items">
                 <li v-for="item, idx in items">
-                  <b>att</b>
-                  <textarea @keyup="keyUpAtt(idx, $event)" class="att" v-bind:name="item.content ? 'items[]' : 'trash'" v-model="item.content" placeholder="fräscha upp motionssystemet och göra det lättare att använda"></textarea>
+                  <b>att<sub>{{ '{{ idx+1 }}' }}</sub></b>
+                  <textarea @keyup="keyUpAtt(idx, $event)"
+                            class="att"
+                            v-bind:name="item.content ? 'items[]' : 'trash'"
+                            v-model="item.content"
+                            placeholder="fräscha upp motionssystemet och göra det lättare att använda">
+                  </textarea>
                 </li>
               </ul>
             </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -93,7 +93,7 @@
             </div>
 
             <div>
-              <h2>Bakgrund</h2>
+              <h3>Bakgrund</h3>
               <textarea @keyup="keyUpBackground($event)"
                         v-model="background"
                         name="background"
@@ -103,7 +103,7 @@
             </div>
 
             <div>
-              <h2>Förslag till beslut</h2>
+              <h3>Förslag till beslut</h3>
 
               <p>
                 Mot bakgrund av ovanstående yrkar jag:
@@ -123,7 +123,7 @@
             </div>
 
             <div>
-              <h2>Undertecknat</h2>
+              <h3>Undertecknat</h3>
               <ul id="authors">
                 <li v-for="author, idx in authors">
                   <input @keyup="keyUpAuthor(idx, $event)"

--- a/templates/index.html
+++ b/templates/index.html
@@ -125,9 +125,9 @@
       new Vue({
         el: '#application',
         data: {
-          title: localStorage.getItem('title'),
-          meeting: localStorage.getItem('meeting'),
-          date: localStorage.getItem('date'),
+          title: localStorage.getItem('title') || '',
+          meeting: localStorage.getItem('meeting') || '',
+          date: localStorage.getItem('date') || '',
           items: JSON.parse(localStorage.getItem('items')) || [{content:''}],
           authors: JSON.parse(localStorage.getItem('authors')) || [{name:''}],
           background: localStorage.getItem('background') || '',
@@ -153,6 +153,7 @@
 
             localStorage.setItem('background', this.background)
           },
+
           keyUpAtt: function(idx, e) {
             this.autogrow(e)
             this.items = this.items.filter((x, idx) => x.content.length > 0 || idx === this.items.length - 1)
@@ -171,6 +172,7 @@
 
             localStorage.setItem('authors', JSON.stringify(this.authors))
           },
+
           submittex: function() {
             this.$refs.form.action = '/motion.tex'
             this.$refs.form.submit()
@@ -178,6 +180,15 @@
           submitpdf: function() {
             this.$refs.form.action = '/motion.pdf'
             this.$refs.form.submit()
+          },
+
+          clearContent: function () {
+            localStorage.removeItem('title')
+            localStorage.removeItem('meeting')
+            localStorage.removeItem('date')
+            localStorage.removeItem('background')
+            localStorage.removeItem('items')
+            localStorage.removeItem('authors')
           }
         }
       })

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,19 +50,38 @@
                 <option value="proposition">Proposition angående</option>
                 <option value="reply">Svar på motion angående</option>
               </select><br>
-              <input type="text" name="title" placeholder="webbaserade motionsmallar">
+              <input @keyup="keyUpTitle()"
+                     v-model="title"
+                     type="text"
+                     name="title"
+                     placeholder="webbaserade motionsmallar">
             </h1>
 
             <br>
 
             <div class="meeting">
-              <input type="text" name="meeting" placeholder="Glögg" class="name"><label for="meeting">-SM</label><br>
-              <input type="date" name="date" placeholder="2011-11-21" class="date">
+              <input @keyup="keyUpMeeting()"
+                     v-model="meeting"
+                     type="text"
+                     name="meeting" class="name"
+                     placeholder="Glögg"><label for="meeting">-SM</label>
+              <br>
+              <input @keyup="keyUpDate()"
+                     v-model="date"
+                     type="date"
+                     name="date"
+                     placeholder="2011-11-21"
+                     class="date">
             </div>
 
             <div>
               <h2>Bakgrund</h2>
-              <textarea @keyup="keyUpBackground($event)" name="background" id="background" v-model="background" placeholder="Folk är lata och tycker att det är jobbigt att skriva motioner i ren LaTeX."></textarea>
+              <textarea @keyup="keyUpBackground($event)"
+                        v-model="background"
+                        name="background"
+                        id="background"
+                        placeholder="Folk är lata och tycker att det är jobbigt att skriva motioner i ren LaTeX.">
+              </textarea>
             </div>
 
             <div>
@@ -76,9 +95,9 @@
                 <li v-for="item, idx in items">
                   <b>att<sub>{{ '{{ idx+1 }}' }}</sub></b>
                   <textarea @keyup="keyUpAtt(idx, $event)"
-                            class="att"
                             v-bind:name="item.content ? 'items[]' : 'trash'"
                             v-model="item.content"
+                            class="att"
                             placeholder="fräscha upp motionssystemet och göra det lättare att använda">
                   </textarea>
                 </li>
@@ -89,7 +108,11 @@
               <h2>Undertecknat</h2>
               <ul id="authors">
                 <li v-for="author, idx in authors">
-                  <input @keyup="keyUpAuthor(idx, $event)" type="text" v-bind:name="author.name ? 'authors[]' : 'trash'" v-model="author.name" placeholder="Jonas Dahl">
+                  <input @keyup="keyUpAuthor(idx, $event)"
+                         type="text"
+                         v-bind:name="author.name ? 'authors[]' : 'trash'"
+                         v-model="author.name"
+                         placeholder="Jonas Dahl">
                 </li>
               </ul>
             </div>
@@ -102,6 +125,9 @@
       new Vue({
         el: '#application',
         data: {
+          title: localStorage.getItem('title'),
+          meeting: localStorage.getItem('meeting'),
+          date: localStorage.getItem('date'),
           items: JSON.parse(localStorage.getItem('items')) || [{content:''}],
           authors: JSON.parse(localStorage.getItem('authors')) || [{name:''}],
           background: localStorage.getItem('background') || '',
@@ -111,6 +137,17 @@
           autogrow: function(e) {
             e.target.style.height = e.target.scrollHeight + 'px'
           },
+
+          keyUpTitle: function () {
+            localStorage.setItem('title', this.title)
+          },
+          keyUpMeeting: function () {
+            localStorage.setItem('meeting', this.meeting)
+          },
+          keyUpDate: function() {
+            localStorage.setItem('date', this.date)
+          },
+
           keyUpBackground: function(e) {
             this.autogrow(e)
 


### PR DESCRIPTION
- attsatser
  - add numbers to attsatser
  - make attsatser not horizontally resizable
  - make attsatser correctly indented
- better alignment for sm-info
- make it so that all inputs persists when refreshing/reopening the page
- add clear button
- make pdf:s open in new tab

Motioner should look basically the same in the frontend as in the generated pdf:s now

Fixes #13 
Fixes #12
Fixes #11

Tested and works locally